### PR TITLE
Allow customization config files for apache2

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -8,6 +8,8 @@ TEMPLATE_SSL="conf/web-ssl"
 TEMPLATE_RAW="conf/web-raw"
 VHOST_INCLUDES_DIR="/etc/${APP_NAME}/addons/apache2/includes/vhost"
 SERVER_INCLUDES_DIR="/etc/${APP_NAME}/addons/apache2/includes/server"
+VHOST_CUSTOMIZATION_DIR="/etc/${APP_NAME}/addons/apache2/custom/vhost"
+SERVER_CUSTOMIZATION_DIR="/etc/${APP_NAME}/addons/apache2/custom/server"
 OSFAMILY="$(wiz_fact osfamily)"
 CONF="/etc/${APP_NAME}/conf.d/server"
 
@@ -17,6 +19,9 @@ mkdir -p "${SERVER_INCLUDES_DIR}"
 # remove existing vhost config files
 rm -f ${VHOST_INCLUDES_DIR}/*.conf
 mkdir -p "${VHOST_INCLUDES_DIR}"
+# add customization dirs
+mkdir -p "${VHOST_CUSTOMIZATION_DIR}"
+mkdir -p "${SERVER_CUSTOMIZATION_DIR}"
 
 enable_apache2_mod() {
 	case "$OSFAMILY" in

--- a/conf/web-raw
+++ b/conf/web-raw
@@ -1,4 +1,5 @@
 Include /etc/_APP_NAME_/addons/apache2/includes/server/*.conf
+Include /etc/_APP_NAME_/addons/apache2/custom/server/*.conf
 
 <VirtualHost *:_RAW_PORT_>
   ServerName _HOSTNAME_
@@ -7,6 +8,7 @@ Include /etc/_APP_NAME_/addons/apache2/includes/server/*.conf
   ProxyRequests off
 
   Include /etc/_APP_NAME_/addons/apache2/includes/vhost/*.conf
+  Include /etc/_APP_NAME_/addons/apache2/custom/vhost/*.conf
 
   # Can't use Location block since it would overshadow all the other proxypass directives on CentOS
   ProxyPass _SERVER_PATH_PREFIX_ http://127.0.0.1:_APP_PORT__SERVER_PATH_PREFIX_ retry=0

--- a/conf/web-ssl
+++ b/conf/web-ssl
@@ -1,4 +1,5 @@
 Include /etc/_APP_NAME_/addons/apache2/includes/server/*.conf
+Include /etc/_APP_NAME_/addons/apache2/custom/server/*.conf
 
 <VirtualHost *:_RAW_PORT_>
   ServerName _HOSTNAME_
@@ -13,6 +14,7 @@ Include /etc/_APP_NAME_/addons/apache2/includes/server/*.conf
   ProxyRequests off
 
   Include /etc/_APP_NAME_/addons/apache2/includes/vhost/*.conf
+  Include /etc/_APP_NAME_/addons/apache2/custom/vhost/*.conf
   
   # Can't use Location block since it would overshadow all the other proxypass directives on CentOS
   ProxyPass _SERVER_PATH_PREFIX_ http://127.0.0.1:_APP_PORT__SERVER_PATH_PREFIX_ retry=0


### PR DESCRIPTION
OpenProject provides some features that require customization of the apache2 config files. In order to do that, we have until now recommended to add a custom include under /etc/openproject/addons/apache2/includes/vhost.

But that folder is cleaned on every installation. To remedy that, I'm suggesting we add a customization dir that the user can put extensions into without getting removed.

I first contemplated using a special naming in the conf folders, but that would make migration a bit more tedious.